### PR TITLE
(SIMP-453) Use the correct ciphers in FIPS mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,4 +44,5 @@ group :system_tests do
   # NOTE: Workaround because net-ssh 2.10 is busting beaker
   # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
   gem 'net-ssh', '~> 2.9.0'
+  gem 'pry-rescue'
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -207,31 +207,29 @@ class vsftpd::config (
   if $xferlog_file { validate_absolute_path($xferlog_file) }
   validate_absolute_path($ca_certs_file)
 
-  $tcp_wrappers       = $::vsftpd::tcp_wrappers
-  $listen_port        = $::vsftpd::listen_port
-  $listen_address     = $::vsftpd::listen_address
-  $client_nets        = $::vsftpd::client_nets
-  $ftp_data_port      = $::vsftpd::ftp_data_port
-  $pasv_enable        = $::vsftpd::pasv_enable
-  $listen_ipv4        = $::vsftpd::listen_ipv4
-  $vsftpd_group       = $::vsftpd::vsftpd_group
-  $vsftpd_user        = $::vsftpd::vsftpd_user
-  $user_list          = $::vsftpd::user_list
-  $ftp_username       = $::vsftpd::vsftpd_user
-  $guest_username     = $::vsftpd::vsftpd_user
-  $userlist_deny      = $::vsftpd::userlist_deny
-  $userlist_enable    = $::vsftpd::userlist_enable
-  $pasv_max_port      = $::vsftpd::pasv_max_port
-  $pasv_min_port      = $::vsftpd::pasv_min_port
-  $local_enable       = $::vsftpd::local_enable
-  $pam_service_name   = $::vsftpd::pam_service_name
-  $ssl_enable         = $::vsftpd::ssl_enable
-  $require_ssl_reuse  = $::vsftpd::require_ssl_reuse
-
+  $_tcp_wrappers       = $::vsftpd::tcp_wrappers
+  $_listen_port        = $::vsftpd::listen_port
+  $_listen_address     = $::vsftpd::listen_address
+  $_ftp_data_port      = $::vsftpd::ftp_data_port
+  $_pasv_enable        = $::vsftpd::pasv_enable
+  $_listen_ipv4        = $::vsftpd::listen_ipv4
+  $_vsftpd_group       = $::vsftpd::vsftpd_group
+  $_ftp_username       = $::vsftpd::vsftpd_user
+  $_user_list          = $::vsftpd::user_list
+  $_guest_username     = $::vsftpd::vsftpd_user
+  $_userlist_deny      = $::vsftpd::userlist_deny
+  $_userlist_enable    = $::vsftpd::userlist_enable
+  $_pasv_max_port      = $::vsftpd::pasv_max_port
+  $_pasv_min_port      = $::vsftpd::pasv_min_port
+  $_local_enable       = $::vsftpd::local_enable
+  $_pam_service_name   = $::vsftpd::pam_service_name
+  $_ssl_enable         = $::vsftpd::ssl_enable
+  $_require_ssl_reuse  = $::vsftpd::require_ssl_reuse
+  $_ssl_ciphers        = $::vsftpd::_enable_fips ? { true => ['FIPS'], default => $ssl_ciphers }
   file { '/etc/vsftpd':
     ensure   => 'directory',
     owner    => 'root',
-    group    => $vsftpd_group,
+    group    => $_vsftpd_group,
     mode     => '0640',
     recurse  => true,
     checksum => undef,
@@ -241,7 +239,7 @@ class vsftpd::config (
 
   file { '/etc/vsftpd/ftpusers':
     owner   => 'root',
-    group   => $vsftpd_group,
+    group   => $_vsftpd_group,
     mode    => '0640',
     source  => 'puppet:///modules/vsftpd/ftpusers',
     notify  => Service['vsftpd'],
@@ -250,7 +248,7 @@ class vsftpd::config (
 
   file { '/etc/vsftpd/user_list':
     owner   => 'root',
-    group   => $vsftpd_group,
+    group   => $_vsftpd_group,
     mode    => '0640',
     content => template('vsftpd/user_list.erb'),
     notify  => Service['vsftpd'],
@@ -267,7 +265,7 @@ class vsftpd::config (
 
   file { '/etc/vsftpd/vsftpd.conf':
     owner   => 'root',
-    group   => $vsftpd_group,
+    group   => $_vsftpd_group,
     mode    => '0640',
     content => template('vsftpd/vsftpd.conf.erb'),
     notify  => Service['vsftpd']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,6 +40,7 @@ class vsftpd::params {
     # Conf Options #
     $user_list        = ['root','bin','daemon','adm','lp','sync','shutdown','halt','mail','news','uucp',	'operator','games','nobody']
     $pam_service_name = 'vsftpd'
+    $use_fips         = defined('$::fips_enabled') ? { true => str2bool($::fips_enabled), default => hiera('use_fips', false) }
   }
   else {
     fail("Unsupported Operating System ${::operatingsystem}")

--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -8,7 +8,6 @@ HOSTS:
     box:        puppetlabs/centos-6.6-64-nocm
     box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
     hypervisor: vagrant
-###    ip:         10.10.10.101
   client:
     roles:
       - agent
@@ -17,7 +16,7 @@ HOSTS:
     box:        puppetlabs/centos-6.6-64-nocm
     box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-6.6-64-nocm
     hypervisor: vagrant
-###    ip:         10.10.10.102
 CONFIG:
   log_level: verbose
   type:      foss
+  vagrant_memsize: 256

--- a/spec/acceptance/nodesets/centos-7-x64.yml
+++ b/spec/acceptance/nodesets/centos-7-x64.yml
@@ -8,7 +8,6 @@ HOSTS:
     box:        puppetlabs/centos-7.0-64-nocm
     box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
-  ### ip:         10.10.10.101
   client:
     roles:
       - client
@@ -17,7 +16,7 @@ HOSTS:
     box:        puppetlabs/centos-7.0-64-nocm
     box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
-  ###  ip:         10.10.10.102
 CONFIG:
   log_level: verbose
   type:      foss
+  vagrant_memsize: 256

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -8,7 +8,6 @@ HOSTS:
     box:        puppetlabs/centos-7.0-64-nocm
     box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
-  ### ip:         10.10.10.101
   client:
     roles:
       - client
@@ -17,7 +16,8 @@ HOSTS:
     box:        puppetlabs/centos-7.0-64-nocm
     box_url:    https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
-  ###  ip:         10.10.10.102
 CONFIG:
   log_level: verbose
   type:      foss
+  vagrant_memsize: 256
+  ## vb_gui: true

--- a/spec/acceptance/nodesets/fedora-20-x64.yml
+++ b/spec/acceptance/nodesets/fedora-20-x64.yml
@@ -10,3 +10,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  vagrant_memsize: 512

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -14,7 +14,6 @@ unless ENV['BEAKER_provision'] == 'no'
   end
 end
 
-
 RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts

--- a/templates/user_list.erb
+++ b/templates/user_list.erb
@@ -4,6 +4,6 @@
 # do not even prompt for a password.
 # Note that the default vsftpd pam config also checks /etc/vsftpd/ftpusers
 # for users that are denied.
-<% @user_list.each do |user| -%>
+<% @_user_list.each do |user| -%>
 <%= user %>
 <% end -%>

--- a/templates/vsftpd.conf.erb
+++ b/templates/vsftpd.conf.erb
@@ -3,7 +3,7 @@
   false => 'NO'
 }
 -%>
-<% if @ssl_enable then -%>
+<% if @_ssl_enable then -%>
 <%   if @allow_anon_ssl then -%>
 allow_anon_ssl=<%= bool_translate[@allow_anon_ssl] %>
 <%   end -%>
@@ -22,9 +22,7 @@ force_local_logins_ssl=<%= bool_translate[@force_local_logins_ssl] %>
 ssl_sslv2=<%= bool_translate[@ssl_sslv2] %>
 ssl_sslv3=<%= bool_translate[@ssl_sslv3] %>
 ssl_tlsv1=<%= bool_translate[@ssl_tlsv1] %>
-<%   if @ssl_ciphers then -%>
-ssl_ciphers=<%= Array(@ssl_ciphers).join(":") %>
-<%   end -%>
+ssl_ciphers=<%= Array(@_ssl_ciphers).join(":") %>
 <%   if @dsa_cert_file then -%>
 dsa_cert_file=<%= @dsa_cert_file %>
 <%   end -%>
@@ -114,9 +112,9 @@ hide_ids=<%= bool_translate[@hide_ids] %>
 <% if @listen_ipv6 && @ipv6_enabled.eql?('true') then -%>
 listen_ipv6=<%= bool_translate[@listen_ipv6] %>
 <% elsif @listen_ipv4 then -%>
-listen=<%= bool_translate[@listen_ipv4] %>
+listen=<%= bool_translate[@_listen_ipv4] %>
 <% end -%>
-local_enable=<%= bool_translate[@local_enable] %>
+local_enable=<%= bool_translate[@_local_enable] %>
 <% if @lock_upload_files then -%>
 lock_upload_files=<%= bool_translate[@lock_upload_files] %>
 <% end -%>
@@ -144,7 +142,7 @@ passwd_chroot_enable=<%= bool_translate[@passwd_chroot_enable] %>
 <% if @pasv_addr_resolve then -%>
 pasv_addr_resolve=<%= bool_translate[@pasv_addr_resolve] %>
 <% end -%>
-pasv_enable=<%= bool_translate[@pasv_enable] %>
+pasv_enable=<%= bool_translate[@_pasv_enable] %>
 <% if @pasv_promiscuous then -%>
 pasv_promiscuous=<%= bool_translate[@pasv_promiscuous] %>
 <% end -%>
@@ -169,10 +167,10 @@ session_support=<%= bool_translate[@session_support] %>
 <% if @setproctitle_enable then -%>
 setproctitle_enable=<%= bool_translate[@setproctitle_enable] %>
 <% end -%>
-ssl_enable=<%= bool_translate[@ssl_enable] %>
-require_ssl_reuse=<%= bool_translate[@require_ssl_reuse] %>
+ssl_enable=<%= bool_translate[@_ssl_enable] %>
+require_ssl_reuse=<%= bool_translate[@_require_ssl_reuse] %>
 syslog_enable=<%= bool_translate[@syslog_enable] %>
-tcp_wrappers=<%= bool_translate[@tcp_wrappers] %>
+tcp_wrappers=<%= bool_translate[@_tcp_wrappers] %>
 <% if @text_userdb_names then -%>
 text_userdb_names=<%= bool_translate[@text_userdb_names] %>
 <% end -%>
@@ -185,8 +183,8 @@ use_localtime=<%= bool_translate[@use_localtime] %>
 <% if @use_sendfile then -%>
 use_sendfile=<%= bool_translate[@use_sendfile] %>
 <% end -%>
-userlist_deny=<%= bool_translate[@userlist_deny] %>
-userlist_enable=<%= bool_translate[@userlist_enable] %>
+userlist_deny=<%= bool_translate[@_userlist_deny] %>
+userlist_enable=<%= bool_translate[@_userlist_enable] %>
 <% if @userlist_log then -%>
 userlist_log=<%= bool_translate[@userlist_log] %>
 <% end -%>
@@ -226,14 +224,12 @@ delay_successful_login=<%= @delay_successful_login %>
 <% if @file_open_mode then -%>
 file_open_mode=<%= @file_open_mode %>
 <% end -%>
-<% if @ftp_data_port then -%>
-ftp_data_port=<%= @ftp_data_port %>
-<% end -%>
+ftp_data_port=<%= @_ftp_data_port %>
 <% if @idle_session_timeout then -%>
 idle_session_timeout=<%= @idle_session_timeout %>
 <% end -%>
-<% if @listen_port then -%>
-listen_port=<%= @listen_port %>
+<% if @_listen_port then -%>
+listen_port=<%= @_listen_port %>
 <% end -%>
 <% if @local_max_rate then -%>
 local_max_rate=<%= @local_max_rate %>
@@ -250,11 +246,11 @@ max_login_fails=<%= @max_login_fails %>
 <% if @max_per_ip then -%>
 max_per_ip=<%= @max_per_ip %>
 <% end -%>
-<% if @pasv_max_port then -%>
-pasv_max_port=<%= @pasv_max_port %>
+<% if @_pasv_max_port then -%>
+pasv_max_port=<%= @_pasv_max_port %>
 <% end -%>
-<% if @pasv_min_port then -%>
-pasv_min_port=<%= @pasv_min_port %>
+<% if @_pasv_min_port then -%>
+pasv_min_port=<%= @_pasv_min_port %>
 <% end -%>
 <% if @trans_chunk_size then -%>
 trans_chunk_size=<%= @trans_chunk_size %>
@@ -280,18 +276,12 @@ deny_file=<%= @deny_file %>
 <% if @email_password_file then -%>
 email_password_file=<%= @email_password_file %>
 <% end -%>
-<% if @ftp_username then -%>
-ftp_username=<%= @ftp_username %>
-<% end -%>
-<% if @guest_username then -%>
-guest_username=<%= @guest_username %>
-<% end -%>
+ftp_username=<%= @_ftp_username %>
+guest_username=<%= @_guest_username %>
 <% if @hide_file then -%>
 hide_file=<%= @hide_file %>
 <% end -%>
-<% if @listen_address then -%>
-listen_address=<%= @listen_address %>
-<% end -%>
+listen_address=<%= @_listen_address %>
 <% if @listen_address6 then -%>
 listen_address6=<%= @listen_address6 %>
 <% end -%>
@@ -301,9 +291,7 @@ local_root=<%= @local_root %>
 <% if @nopriv_user then -%>
 nopriv_user=<%= @nopriv_user %>
 <% end -%>
-<% if @pam_service_name then -%>
-pam_service_name=<%= @pam_service_name %>
-<% end -%>
+pam_service_name=<%= @_pam_service_name %>
 <% if @pasv_address then -%>
 pasv_address=<%= @pasv_address %>
 <% end -%>


### PR DESCRIPTION
Before this patch, vsftpd would fail in FIPS mode unless the ssl_ciphers
were manually set to `FIPS`.  This update introduces logic to use the
correct ciphers if FIPS mode is enabled (determined by the fact
`fips_enabled`) or desired (expressed iva the hiera global `use_fips` or
the `vsftpd::use_fips` parameter).

This update also prefixes locally-scoped variables with `_`

SIMP-453 #close #comment Use correct ciphers when in FIPS mode