### PR TITLE
(SIMP-508) Updated location of PKI files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts"
-  gem 'simp-beaker-helpers'
+  gem 'simp-beaker-helpers', '>= 1.0.4'
 
   # simp-rake-helpers does not suport puppet 2.7.X
   # FIXME: simp-rake-helpers should support Puppet 4.X

--- a/spec/acceptance/ftp_tls_connection_spec.rb
+++ b/spec/acceptance/ftp_tls_connection_spec.rb
@@ -109,9 +109,9 @@ describe 'An FTP-over-TLS session' do
 
   context 'connection' do
     let(:curl_ftp_cmd) {
-      'curl --verbose --cacert /etc/pki/simp-testing/cacerts/cacerts.pem ' +
-      "--key /etc/pki//simp-testing/private/#{client_fqdn}.pem " +
-      "--cert /etc/pki/simp-testing/public/#{client_fqdn}.pub " +
+      'curl --verbose --cacert /etc/pki/simp-testing/pki/cacerts/cacerts.pem ' +
+      "--key /etc/pki//simp-testing/pki/private/#{client_fqdn}.pem " +
+      "--cert /etc/pki/simp-testing/pki/public/#{client_fqdn}.pub " +
       "--ftp-ssl ftp://foo:foo@#{server_fqdn}"
       # ^^ these arguments are deprecated in modern curl, but EL6 needs them.
       # In the future, '--ssl --ss-reqd' should replace '--ftp-ssl' here


### PR DESCRIPTION
The new simp-beaker-helpers matches the location that ::pki::copy would
use.

SIMP-508 #comment Update for the acceptance tests

Change-Id: I7a87cd980cb1f26f93e765665eeddf72f328703a