### PR TITLE
(SIMP-1574) Fix Forge `haveged` dependency name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.5-0
+- Fix Forge `haveged` dependency name
+
 * Mon Jul 11 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.4-0
 - Migration to semantic versioning and fix of the build system
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-vsftpd",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "author": "simp",
   "summary": "Manage vsftpd",
   "license": "Apache-2.0",
@@ -17,7 +17,7 @@
       "version_requirement": ">= 1.0.0"
     },
     {
-      "name": "simp/puppet-haveged",
+      "name": "simp/haveged",
       "version_requirement": ">= 0.3.0 < 1.0.0"
     },
     {


### PR DESCRIPTION
`metadata.json` erroneously claimed `simp/puppet-haveged` as a
dependency, which causes a fatal error when pushing to the Forge.

This patch corrects the dependency name  to `simp/haveged`.

SIMP-1574 #comment fixed pupmod-simp-vsftpd