### PR TITLE
(SIMP-1574) Version bump to fix Forge push

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-vsftpd",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "author": "simp",
   "summary": "Manage vsftpd",
   "license": "Apache-2.0",


### PR DESCRIPTION
The 5.0.5 Forge push included the `dist/` directory and was deleted.
This patch bumps the version to prepare for a second Forge push.