### PR TITLE
(SIMP-1450) Update Requires

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -9,7 +9,7 @@ Requires: pupmod-simp-iptables < 5.0.0-0
 Requires: pupmod-simp-iptables >= 4.1.4-0
 Requires: pupmod-simp-pki < 5.0.0-0
 Requires: pupmod-simp-pki >= 4.2.4-0
-Requires: pupmod-simp-simplib < 2.0.0-0
-Requires: pupmod-simp-simplib >= 1.3.1-0
-Requires: pupmod-simp-tcpwrappers < 5.0.0-0
-Requires: pupmod-simp-tcpwrappers >= 4.1.0-0
+Requires: pupmod-simp-simplib >= 2.0.0-0
+Requires: pupmod-simp-simplib < 3.0.0-0
+Requires: pupmod-simp-tcpwrappers >= 5.0.0-0
+Requires: pupmod-simp-tcpwrappers < 6.0.0-0

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 1.3.1 < 2.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
       "name": "simp/haveged",
@@ -26,7 +26,7 @@
     },
     {
       "name": "simp/tcpwrappers",
-      "version_requirement": ">= 4.1.0 < 5.0.0"
+      "version_requirement": ">= 5.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
```
update requires and metadata to use new versions
of simp modules for SIMP 6.
```

SIMP-1450 #close
