### PR TITLE
(SIMP-5304) updated $app_pki_external_source type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Sep 11 2018 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 7.1.1-0
+- Updated $app_pki_external_source to accept any string. This matches the
+  functionality of pki::copy.
+
 * Wed Nov 15 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 7.1.0-0
 - By default, use TLS 1.2 instead of TLS 1.0.
 - Eliminate the use of deprecated validate_net_list() through

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -132,7 +132,7 @@ class vsftpd::config (
   Optional[Stdlib::Absolutepath]  $message_file             = undef,
   Optional[String]                $nopriv_user              = undef,
   Optional[Simplib::Host]         $pasv_address             = undef,
-  Stdlib::Absolutepath            $app_pki_external_source  = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
+  String                          $app_pki_external_source  = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
   Stdlib::Absolutepath            $app_pki_dir              = '/etc/pki/simp_apps/vsftpd/x509',
   Stdlib::Absolutepath            $app_pki_cert             = "${app_pki_dir}/public/${::fqdn}.pub",
   Stdlib::Absolutepath            $app_pki_key              = "${app_pki_dir}/private/${::fqdn}.pem",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-vsftpd",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "author": "SIMP Team",
   "summary": "Manage vsftpd",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Updated $app_pki_external_source to accept any string. This matches the
  functionality of pki::copy.

SIMP-5296 #comment Updated vsftpd
SIMP-5304 #close