### PR TITLE
(SIMP-6213) Use latest concat in tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,11 +1,7 @@
 ---
 fixtures:
   repositories:
-    concat:
-      # master is beyond 4.1.1, but has breaking changes to
-      # how fragments are ordered (MODULES-6625)
-      repo: https://github.com/simp/puppetlabs-concat
-      ref: 4.1.1
+    concat: https://github.com/simp/puppetlabs-concat
     haveged: https://github.com/simp/pupmod-simp-haveged
     iptables: https://github.com/simp/pupmod-simp-iptables
     pki: https://github.com/simp/pupmod-simp-pki

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Oct 29 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.2.1-0
+- Fix a bad URL in the README.md
+
 * Mon Oct 29 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 7.2.0-0
 - Update badges and contribution guide URL in README.md
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This module is a component of the [System Integrity Management Platform](https:/
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
 
 ## Work in Progress
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-vsftpd",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "author": "SIMP Team",
   "summary": "Manage vsftpd",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Test with latest concat Puppet module instead of 4.1.1
- Fix a bad URL in the README.md

SIMP-6213 #comment pupmod-simp-vsftpd