### PR TITLE
SIMP-7461 Add EL8 Support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,6 +9,9 @@ fixtures:
     augeasproviders_grub: https://github.com/simp/augeasproviders_grub
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
     concat: https://github.com/simp/puppetlabs-concat
+    firewalld:
+      repo: https://github.com/simp/pupmod-voxpupuli-firewalld
+      ref: v4.2.4
     haveged: https://github.com/simp/pupmod-simp-haveged
     iptables: https://github.com/simp/pupmod-simp-iptables
     logrotate: https://github.com/simp/pupmod-simp-logrotate

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,9 +5,9 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# SIMP 6.3      5.5.10   2.4.5  TBD***
-# PE 2018.1     5.5.8    2.4.5  2020-05 (LTS)***
-# PE 2019.0     6.0      2.5.1  2019-08-31^^^
+# SIMP 6.3      5.5.16   2.4.5  TBD***
+# PE 2018.1     5.5.16   2.4.5  2020-05 (LTS)***
+# PE 2019.0     6.0      2.5.3  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
 ---
@@ -69,10 +69,10 @@ variables:
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
-.pup_5_5_10: &pup_5_5_10
+.pup_5_5_16: &pup_5_5_16
   image: 'ruby:2.4'
   variables:
-    PUPPET_VERSION: '5.5.10'
+    PUPPET_VERSION: '5.5.16'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
@@ -110,6 +110,9 @@ variables:
 .compliance_base: &compliance_base
   stage: 'compliance'
   tags: ['beaker']
+  # There is a bug in inspec that is going to always cause this to fail until it
+  # is fixed: https://github.com/inspec/inspec/pull/4665
+  allow_failure: true
   <<: *setup_bundler_env
 
 
@@ -149,8 +152,8 @@ pup5-unit:
   <<: *pup_5
   <<: *unit_tests
 
-pup5.5.10-unit:
-  <<: *pup_5_5_10
+pup5.5.16-unit:
+  <<: *pup_5_5_16
   <<: *unit_tests
 
 pup6-unit:
@@ -159,26 +162,26 @@ pup6-unit:
 
 # Acceptance tests
 # ==============================================================================
-pup5.5.10:
-  <<: *pup_5_5_10
+pup5.5.16:
+  <<: *pup_5_5_16
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites'
+    - 'bundle exec rake beaker:suites[default]'
 
-pup5.5.10-fips:
-  <<: *pup_5_5_10
+pup5.5.16-fips:
+  <<: *pup_5_5_16
   <<: *acceptance_base
   script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'
 
-pup5.5.10-oel:
-  <<: *pup_5_5_10
+pup5.5.16-oel:
+  <<: *pup_5_5_16
   <<: *acceptance_base
   script:
     - 'bundle exec rake beaker:suites[default,oel]'
 
-pup5.5.10-oel-fips:
-  <<: *pup_5_5_10
+pup5.5.16-oel-fips:
+  <<: *pup_5_5_16
   <<: *acceptance_base
   <<: *only_with_SIMP_FULL_MATRIX
   script:
@@ -188,10 +191,10 @@ pup6:
   <<: *pup_6
   <<: *acceptance_base
   script:
-    - 'bundle exec rake beaker:suites'
+    - 'bundle exec rake beaker:suites[default]'
 
 pup6-fips:
   <<: *pup_6
   <<: *acceptance_base
   script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default]'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,18 @@
+* Fri Apr 10 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.4.0-0
+- Add EL8 support
+- The following dependencies are now optional
+  - simp/haveged
+  - simp/iptables
+  - simp/pki
+  - simp/tcpwrappers
+- Updated acceptance tests to use lftp in TLS mode and fixed SELinux issues
+- Updated the README
+
 * Tue Jun 04 2019 Steven Pritchard <steven.pritchard@onyxpoint.com> - 7.3.0-0
 - Add v2 compliance_markup data
 
 * Wed Apr 10 2019 Joseph Sharkey <shark.bruhaha@gmail.com> - 7.2.1-0
-- Fixed ordering issue between the kernel module loading for 
+- Fixed ordering issue between the kernel module loading for
   iptables and the service being started
 - Updated tests in support of puppet6, and removed puppet4 support
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,115 @@
 [![Puppet Forge Downloads](https://img.shields.io/puppetforge/dt/simp/vsftpd.svg)](https://forge.puppetlabs.com/simp/vsftpd)
 [![Build Status](https://travis-ci.org/simp/pupmod-simp-vsftpd.svg)](https://travis-ci.org/simp/pupmod-simp-vsftpd)
 
+#### Table of Contents
+
+<!-- vim-markdown-toc GFM -->
+
+* [Overview](#overview)
+* [This is a SIMP module](#this-is-a-simp-module)
+* [Module Description](#module-description)
+* [Usage](#usage)
+  * [A Basic Anonymous FTP Server](#a-basic-anonymous-ftp-server)
+  * [A TLS Protected FTP Server with Local Accounts](#a-tls-protected-ftp-server-with-local-accounts)
+* [Development](#development)
+  * [Acceptance tests](#acceptance-tests)
+
+<!-- vim-markdown-toc -->
+
+## Overview
+
+This module manages [vsftpd](https://security.appspot.com/vsftpd.html) on
+supported systems.
 
 ## This is a SIMP module
-This module is a component of the [System Integrity Management Platform](https://simp-project.com), a compliance-management framework built on Puppet.
+
+This module is a component of the [System Integrity Management Platform](https://simp-project.com),
+a compliance-management framework built on Puppet.
 
 If you find any issues, they can be submitted to our [JIRA](https://simp-project.atlassian.net/).
 
-Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).
+This module is optimally designed for use within a larger SIMP ecosystem, but it can be used independently:
+* When included within the SIMP ecosystem, security compliance settings will be
+  managed from the Puppet server.
+* If used independently, all SIMP-managed security subsystems will be disabled by
+  default and must be explicitly opted into by administrators.  Please review
+  ``simp_options`` for details.
 
-## Work in Progress
+## Module Description
 
-Please excuse us as we transition this code into the public domain.
+This module can be used for the configuration of vsftpd and includes support for
+setting up TLS protected servers.
 
-Downloads, discussion, and patches are still welcome!
+## Usage
+
+### A Basic Anonymous FTP Server
+
+```puppet
+# If you're not using the SIMP iptables module, you'll need to make sure the
+# PASV ports are accessiable using your preferred method.
+
+class { 'vsftpd':
+  ssl_enable    => false,
+  pasv_min_port => 10000,
+  pasv_max_port => 20000
+}
+```
+
+### A TLS Protected FTP Server with Local Accounts
+
+```puppet
+# If you're not using the SIMP iptables module, you'll need to make sure the
+# PASV ports are accessiable using your preferred method.
+
+# If you decide not to use the SIMP PKI module, you'll need to manage the
+# certificate locations on the filesystem yourself using the options in
+# vsftpd::config
+
+# You may need to flip one or more SELinux booleans depending on your setup.
+# This really depends on your system so it cannot be automated cleanly.
+
+class { 'vsftpd':
+  local_enable  => true,
+  ssl_enable    => true,
+  pasv_min_port => 10000,
+  pasv_max_port => 20000
+}
+```
+
+## Development
+
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/Contribution_Procedure.html)
+
+### Acceptance tests
+
+This module includes [Beaker](https://github.com/puppetlabs/beaker) acceptance
+tests using the SIMP [Beaker Helpers](https://github.com/simp/rubygem-simp-beaker-helpers).
+By default the tests use [Vagrant](https://www.vagrantup.com/) with
+[VirtualBox](https://www.virtualbox.org) as a back-end; Vagrant and VirtualBox
+must both be installed to run these tests without modification. To execute the
+tests run the following:
+
+```shell
+bundle exec rake beaker:suites
+```
+
+Some environment variables may be useful:
+
+```shell
+BEAKER_debug=true
+BEAKER_provision=no
+BEAKER_destroy=no
+BEAKER_use_fixtures_dir_for_modules=yes
+BEAKER_fips=yes
+```
+
+* `BEAKER_debug`: show the commands being run on the STU and their output.
+* `BEAKER_destroy=no`: prevent the machine destruction after the tests finish so you can inspect the state.
+* `BEAKER_provision=no`: prevent the machine from being recreated. This can save a lot of time while you're writing the tests.
+* `BEAKER_use_fixtures_dir_for_modules=yes`: cause all module dependencies to be loaded from the `spec/fixtures/modules` directory, based on the contents of `.fixtures.yml`.  The contents of this directory are usually populated by `bundle exec rake spec_prep`.  This can be used to run acceptance tests to run on isolated networks.
+* `BEAKER_fips=yes`: enable FIPS-mode on the virtual instances. This can
+  take a very long time, because it must enable FIPS in the kernel
+  command-line, rebuild the initramfs, then reboot.
+
+Please refer to the [SIMP Beaker Helpers documentation](https://github.com/simp/rubygem-simp-beaker-helpers/blob/master/README.md)
+for more information.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -40,7 +40,7 @@ Default value: simplib::lookup('simp_options::trusted_nets', { 'default_value' =
 
 Data type: `Boolean`
 
-If true, use SIMP's ::iptables to manage firewall rules to accommodate <%= metadata.name %>.
+If true, use SIMP's `iptables` to manage firewall rules to accommodate <%= metadata.name %>.
 
 Default value: simplib::lookup('simp_options::firewall', { 'default_value' => false })
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -173,6 +173,8 @@ class vsftpd::config (
   $_ssl_ciphers        = $vsftpd::cipher_suite
 
   if $::vsftpd::pki {
+    simplib::assert_optional_dependency($module_name, 'simp/pki')
+
     pki::copy { 'vsftpd':
       source => $app_pki_external_source,
       pki    => $vsftpd::pki,

--- a/manifests/config/firewall.pp
+++ b/manifests/config/firewall.pp
@@ -12,40 +12,50 @@ class vsftpd::config::firewall {
   assert_private()
 
   # TODO support ipv6
-  if $::vsftpd::listen_ipv4 {
-    include '::iptables'
+  if $vsftpd::listen_ipv4 {
+    simplib::assert_optional_dependency($module_name, 'simp/iptables')
+
+    include 'iptables'
 
     iptables::listen::tcp_stateful { 'allow_vsftpd_data_port':
-      trusted_nets => $::vsftpd::trusted_nets,
-      dports       => $::vsftpd::ftp_data_port
+      trusted_nets => $vsftpd::trusted_nets,
+      dports       => $vsftpd::ftp_data_port
     }
 
     iptables::listen::tcp_stateful { 'allow_vsftpd_listen_port':
-      trusted_nets => $::vsftpd::trusted_nets,
-      dports       => $::vsftpd::listen_port
+      trusted_nets => $vsftpd::trusted_nets,
+      dports       => $vsftpd::listen_port
     }
 
-    if $::vsftpd::pasv_enable {
-      if $::vsftpd::pasv_min_port and $::vsftpd::pasv_max_port {
+    if $vsftpd::pasv_enable {
+      if $vsftpd::pasv_min_port and $vsftpd::pasv_max_port {
         iptables::listen::tcp_stateful { 'allow_vsftpd_pasv_ports':
-          trusted_nets => $::vsftpd::trusted_nets,
-          dports       => "${::vsftpd::pasv_min_port}:${::vsftpd::pasv_max_port}",
+          trusted_nets => $vsftpd::trusted_nets,
+          dports       => "${vsftpd::pasv_min_port}:${vsftpd::pasv_max_port}",
         }
-      } elsif $::vsftpd::pasv_min_port or $::vsftpd::pasv_max_port {
-        fail("\$::vsftpd::pasv_min_port ('${::vsftpd::pasv_min_port}') and \$::vsftpd::pasv_max_port ('${::vsftpd::pasv_max_port}') must both be defined (or not defined)")
+      }
+      elsif $vsftpd::pasv_min_port or $vsftpd::pasv_max_port {
+        fail("\$vsftpd::pasv_min_port ('${vsftpd::pasv_min_port}') and \$vsftpd::pasv_max_port ('${vsftpd::pasv_max_port}') must both be defined (or not defined)")
       }
 
       # This feels like a hack.
       exec { 'check_conntrack_ftp':
         command => '/bin/true',
-        onlyif  => '/bin/grep -F "nf_conntrack_ftp" /proc/modules; test $? -ne 0',
-        notify  => Service['iptables']
+        onlyif  => '/bin/grep -F "nf_conntrack_ftp" /proc/modules; test $? -ne 0'
       }
 
       exec { 'nf_conntrack_ftp':
         command     => '/sbin/modprobe -q nf_conntrack_ftp',
-        refreshonly => true,
-        subscribe   => Service['iptables']
+        refreshonly => true
+      }
+
+      if defined(Class['iptables::service']) {
+        Exec['check_conntrack_ftp'] ~> Class['iptables::service']
+        Class['iptables::service'] ~> Exec['nf_conntrack_ftp']
+      }
+      elsif defined(Class['firewalld::reload']) {
+        Exec['check_conntrack_ftp'] ~> Class['firewalld::reload']
+        Class['firewalld::reload'] ~> Exec['nf_conntrack_ftp']
       }
     }
   }

--- a/manifests/config/tcpwrappers.pp
+++ b/manifests/config/tcpwrappers.pp
@@ -5,6 +5,8 @@
 class vsftpd::config::tcpwrappers {
   assert_private()
 
+  simplib::assert_optional_dependency($module_name, 'simp/tcpwrappers')
+
   include '::tcpwrappers'
 
   tcpwrappers::allow { 'vsftpd':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@
 #   A whitelist of subnets (in CIDR notation) permitted access.
 #
 # @param firewall
-#   If true, use SIMP's ::iptables to manage firewall rules to accommodate <%= metadata.name %>.
+#   If true, use SIMP's `iptables` to manage firewall rules to accommodate <%= metadata.name %>.
 #
 # @param pki
 #   * If 'simp', include SIMP's pki module and use pki::copy to manage
@@ -97,6 +97,8 @@ class vsftpd (
 ) {
 
   if $haveged and $ssl_enable {
+    simplib::assert_optional_dependency($module_name, 'simp/haveged')
+
     include 'haveged'
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-vsftpd",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "author": "SIMP Team",
   "summary": "Manage vsftpd",
   "license": "Apache-2.0",
@@ -10,62 +10,65 @@
   "tags": [
     "simp",
     "vsftpd",
-    "ftp"
+    "ftp",
+    "compliance",
+    "DISA STIG",
+    "STIG",
+    "NIST 800-53"
   ],
   "dependencies": [
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
-    },
-    {
-      "name": "simp/haveged",
-      "version_requirement": ">= 0.3.2 < 1.0.0"
-    },
-    {
-      "name": "simp/logrotate",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
-    },
-    {
-      "name": "simp/pki",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
-    },
-    {
-      "name": "simp/rsyslog",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
-    },
-    {
-      "name": "simp/tcpwrappers",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 3.1.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 7.0.0"
-    },
-    {
-      "name": "simp/iptables",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
     }
   ],
+  "simp": {
+    "optional_dependencies": [
+      {
+        "name": "simp/haveged",
+        "version_requirement": ">= 0.3.2 < 1.0.0"
+      },
+      {
+        "name": "simp/iptables",
+        "version_requirement": ">= 6.0.0 < 7.0.0"
+      },
+      {
+        "name": "simp/pki",
+        "version_requirement": ">= 6.0.0 < 7.0.0"
+      },
+      {
+        "name": "simp/tcpwrappers",
+        "version_requirement": ">= 6.0.0 < 7.0.0"
+      }
+    ]
+  },
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "6",
-        "7"
+        "7",
+        "8"
       ]
     }
   ],

--- a/spec/acceptance/nodesets/centos.yml
+++ b/spec/acceptance/nodesets/centos.yml
@@ -6,28 +6,40 @@
   end
 -%>
 HOSTS:
-  server7:
+  el7-server:
     roles:
-      - server7
+      - server
       - default
     platform: el-7-x86_64
     box: centos/7
     hypervisor: <%= hypervisor %>
-  client7:
+  el7-client:
     roles:
-      - client7
+      - client
     platform: el-7-x86_64
     box: centos/7
     hypervisor: <%= hypervisor %>
-  server6:
+  el8-server:
     roles:
-      - server6
+      - server
+    platform: el-8-x86_64
+    box: centos/8
+    hypervisor: <%= hypervisor %>
+  el8-client:
+    roles:
+      - client
+    platform: el-8-x86_64
+    box: centos/8
+    hypervisor: <%= hypervisor %>
+  el6-server:
+    roles:
+      - server
     platform: el-6-x86_64
     box: centos/6
     hypervisor: <%= hypervisor %>
-  client6:
+  el6-client:
     roles:
-      - client6
+      - client
     platform: el-6-x86_64
     box: centos/6
     hypervisor: <%= hypervisor %>

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -6,31 +6,78 @@
   end
 -%>
 HOSTS:
-  server7:
+  oel7-server:
     roles:
-      - server7
+      - server
       - default
     platform: el-7-x86_64
-    box: onyxpoint/oel-7-x86_64
+    box: generic/oracle7
     hypervisor: <%= hypervisor %>
-  client7:
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
+        gpgkeys:
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
+
+  oel7-client:
     roles:
-      - client7
+      - client
     platform: el-7-x86_64
-    box: onyxpoint/oel-7-x86_64
+    box: generic/oracle7
     hypervisor: <%= hypervisor %>
-  server6:
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
+        gpgkeys:
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
+
+  oel8-server:
     roles:
-      - server6
+      - server
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: <%= hypervisor %>
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch'
+        gpgkeys:
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
+
+  oel8-client:
+    roles:
+      - client
+    platform: el-8-x86_64
+    box: generic/oracle8
+    hypervisor: <%= hypervisor %>
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch'
+        gpgkeys:
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
+
+  oel6-server:
+    roles:
+      - server
     platform: el-6-x86_64
     box: onyxpoint/oel-6-x86_64
     hypervisor: <%= hypervisor %>
-  client6:
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
+        gpgkeys:
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
+
+  oel6-client:
     roles:
-      - client6
+      - client
     platform: el-6-x86_64
     box: onyxpoint/oel-6-x86_64
     hypervisor: <%= hypervisor %>
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
+        gpgkeys:
+          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 CONFIG:
   log_level: verbose
   type: aio

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -38,8 +38,8 @@ hosts_with_role(hosts, 'server').each do |server|
 
       it 'should have vsftpd service enabled and running' do
         result = on(server, 'puppet resource service vsftpd')
-        expect(result.stdout).to match(/ensure => 'running'/)
-        expect(result.stdout).to match(/enable => 'true'/)
+        expect(result.stdout).to match(/ensure\s+=>\s+'running'/)
+        expect(result.stdout).to match(/enable\s+=>\s+'true'/)
       end
 
       it 'should be listening on port 21' do

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -2,12 +2,9 @@ require 'spec_helper_acceptance'
 
 test_name 'vsftpd class'
 
-['6', '7'].each do |os_major_version|
-  describe "vsftpd class for CentOS #{os_major_version}" do
-    let(:client) { only_host_with_role( hosts, "client#{os_major_version}" ) }
-    let(:server) { only_host_with_role( hosts, "server#{os_major_version}" ) }
-
-    let(:manifest) { "include 'vsftpd'"}
+hosts_with_role(hosts, 'server').each do |server|
+  describe "with server '#{server}'" do
+    let(:manifest) { 'include vsftpd' }
 
     let(:hieradata) {
       <<-EOS
@@ -46,7 +43,7 @@ test_name 'vsftpd class'
       end
 
       it 'should be listening on port 21' do
-        on(server, "netstat -ntap | grep '^tcp.* 0.0.0.0:21 .*/vsftpd'", :acceptable_exit_codes => [0])
+        on(server, %q{ss -plant | grep ':21 .*vsftpd'})
       end
     end
   end

--- a/spec/acceptance/suites/default/05_ftp_connection_spec.rb
+++ b/spec/acceptance/suites/default/05_ftp_connection_spec.rb
@@ -2,171 +2,167 @@ require 'spec_helper_acceptance'
 
 test_name 'ftp connection'
 
-['6', '7'].each do |os_major_version|
-  describe "An anonymous (plaintext) FTP session for CentOS #{os_major_version}" do
-    before(:all) do
-      # Ensure that our test doesn't match messages from other tests
-      @msg_uuid = @msg_uuid || {}
-      @msg_uuid[__FILE__] = Time.now.to_f.to_s.gsub('.','_') + '_PLAINTEXT'
-    end
+describe 'An anonymous (plaintext) FTP session' do
+  hosts_with_role(hosts, 'server').each do |server|
+    describe "with server '#{server}'" do
+      hosts_with_role(hosts, 'client').each do |client|
+        describe "with client '#{client}'" do
+          before(:all) do
+            # Ensure that our test doesn't match messages from other tests
+            @msg_uuid = @msg_uuid || {}
+            @msg_uuid[__FILE__] = Time.now.to_f.to_s.gsub('.','_') + '_PLAINTEXT'
+          end
 
-    let(:client) { only_host_with_role( hosts, "client#{os_major_version}" ) }
-    let(:server) { only_host_with_role( hosts, "server#{os_major_version}" ) }
-    let(:client_fqdn){ fact_on( client, 'fqdn' ) }
-    let(:server_fqdn){ fact_on( server, 'fqdn' ) }
+          let(:client_fqdn){ fact_on( client, 'fqdn' ) }
+          let(:server_fqdn){ fact_on( server, 'fqdn' ) }
 
-    let(:client_manifest) {
-      <<-EOS
-        # Switch firewall control from firewalld over to iptables in EL7
-        # Presumably this would already be done on a runnying system.
-        include 'iptables'
-        iptables::listen::tcp_stateful { 'ssh':
-          dports       => 22,
-          trusted_nets => ['any'],
-        }
-        # FTP and its ephemeral ports
-        iptables::listen::tcp_stateful { 'ephemeral_ports':
-          dports       => '32768:61000',
-          trusted_nets => ['any'],
-        }
+          let(:client_manifest) {
+            <<-EOS
+              # Switch firewall control from firewalld over to iptables in EL7
+              # Presumably this would already be done on a runnying system.
+              include 'iptables'
+              iptables::listen::tcp_stateful { 'ssh':
+                dports       => 22,
+                trusted_nets => ['any'],
+              }
+              # FTP and its ephemeral ports
+              iptables::listen::tcp_stateful { 'ephemeral_ports':
+                dports       => '32768:61000',
+                trusted_nets => ['any'],
+              }
 
-        # A client to test the FTP connection
-        # (curl gives nice exit codes and supports ftps)
-        package{ 'curl': ensure => present }
+              # A client to test the FTP connection
+              package{ 'lftp': ensure => present }
 
-        file{ '/root/TEST.upload.#{@msg_uuid[__FILE__]}':
-          ensure  => 'file',
-          content => '123',
-          mode    => '644',
-          owner   => 'root',
-        }
-      EOS
-    }
+              file{ '/root/TEST.upload.#{@msg_uuid[__FILE__]}':
+                ensure  => 'file',
+                content => '123',
+                mode    => '644',
+                owner   => 'root',
+              }
+            EOS
+          }
 
-    let(:client_hieradata) {{
-      'simp_options::firewall'     => true,
-      'simp_options::trusted_nets' => ['any']
-    }}
+          let(:client_hieradata) {{
+            'simp_options::firewall'     => true,
+            'simp_options::trusted_nets' => ['any']
+          }}
 
-    let(:server_manifest) {
-      <<-EOS
-        # Switch firewall control from firewalld over to iptables in EL7
-        # Presumably this would already be done on a runnying system.
-        include 'iptables'
-        iptables::listen::tcp_stateful { 'ssh':
-          dports       => 22,
-          trusted_nets => ['any'],
-        }
-        # FTP and its ephemeral ports
-        iptables::listen::tcp_stateful { 'ephemeral_ports':
-          dports       => '32768:61000',
-          trusted_nets => ['any'],
-        }
+          let(:server_manifest) {
+            <<-EOS
+              include 'iptables'
 
-        # install and start vsftpd without SSL
-        class { 'vsftpd':
-          ssl_enable    => false,
-          pasv_enable   => true,
-          pasv_min_port => 10000,
-          pasv_max_port => 10100
-        }
-        ->
-        file{ '/var/ftp/pub/TEST.download.#{@msg_uuid[__FILE__]}':
-          ensure  => 'file',
-          content => '456',
-          mode    => '644',
-          owner   => 'root',
-        }
-      EOS
-    }
+              iptables::listen::tcp_stateful { 'ssh':
+                dports       => 22,
+                trusted_nets => ['any'],
+              }
 
-    let(:server_hieradata) {{
-      'simp_options::firewall'     => true,
-      'simp_options::trusted_nets' => ['any']
-    }}
+              # install and start vsftpd without SSL
+              class { 'vsftpd':
+                ssl_enable    => false,
+                pasv_min_port => 10000,
+                pasv_max_port => 10100
+              }
+              ->
+              file{ '/var/ftp/pub/TEST.download.#{@msg_uuid[__FILE__]}':
+                ensure  => 'file',
+                content => '456',
+                mode    => '644',
+                owner   => 'root',
+              }
+            EOS
+          }
 
-    context 'basic puppet apply' do
+          let(:server_hieradata) {{
+            'simp_options::firewall'     => true,
+            'simp_options::trusted_nets' => ['any']
+          }}
 
-      it 'should install epel' do
-        install_package(server, 'epel-release')
-        install_package(client, 'epel-release')
+          context 'basic puppet apply' do
+
+            it 'should install epel' do
+              install_package(server, 'epel-release')
+              install_package(client, 'epel-release')
+            end
+
+            it 'should configure server without errors' do
+              set_hieradata_on(server, server_hieradata)
+              apply_manifest_on(server, server_manifest, :catch_failures => false)
+              # Our exec 'hack' takes an extra run.
+              apply_manifest_on(server, server_manifest, :catch_failures => true)
+            end
+
+            it 'should configure server idempotently' do
+              apply_manifest_on(server, server_manifest, :catch_changes => true)
+            end
+
+            it 'should configure client without errors' do
+              set_hieradata_on(client, client_hieradata)
+              apply_manifest_on(client, client_manifest, :catch_failures => true)
+            end
+
+            it 'should configure client idempotently' do
+              apply_manifest_on(client, client_manifest, :catch_changes => true)
+            end
+          end
+
+          context 'connection' do
+            let(:ftp_cmd){ "lftp ftp://#{server_fqdn}/pub/" }
+
+            it 'should successfully log in with active anonymous FTP' do
+              on( client, "#{ftp_cmd} -e 'ls; exit'", :acceptable_exit_codes => [0] )
+            end
+
+            it 'should successfully download a file using anonymous FTP' do
+              on( client, "#{ftp_cmd} -e 'get TEST.download.#{@msg_uuid[__FILE__]}; exit'", :acceptable_exit_codes => [0] )
+            end
+
+            # anonymous FTP cannot upload by default
+            it 'should fail to upload a file using anonymous FTP' do
+              on( client, %Q(#{ftp_cmd} -e 'put /root/TEST.upload.#{@msg_uuid[__FILE__]}; exit'), :acceptable_exit_codes => [1] )
+            end
+
+            ### # NOTE: Commented out because FTP client is ridiculous, but keeping in back
+            ###         pocket because there's a chance we might want it and it was a PITA
+            ###         to set up.  Remove before committing.
+            ###  let(:netrc_template) {
+            ###    <<-EOS
+            ###machine SERVER
+            ###        login LOGIN
+            ###        password PASSWORD
+            ###
+            ###macdef connection_test
+            ###        cd /pub
+            ###        ls -la
+            ###        quit
+            ###
+            ###macdef upload_test
+            ###        cd /pub/tests
+            ###        bin
+            ###        put filename.tar.gz
+            ###        quit
+            ###
+            ###    EOS
+            ###  }
+            # wget handles FTP and returns exit codes on failure
+            # on( client, %Q(wget --no-passive-ftp --spider ftp://#{server_fqdn}/pub/), :acceptable_exit_codes => [0] )
+            # curl handles FTP and returns exit codes on failure
+            # stage a .netrc file
+            ### netrc_text = netrc_template
+            ###               .sub( 'SERVER',   server_fqdn   )
+            ###               .sub( 'LOGIN',    'anonymous'   )
+            ###               .sub( 'PASSWORD', 'foo@foo.foo' )
+            ### apply_manifest_on(client, "file{'/root/.netrc': content => '#{netrc_text}' }", :catch_failures => true)
+
+            ### connect to FTP server, then check log for FTP error codes
+            ### on( client, %Q(echo "\\$ connection_test" | ftp #{server_fqdn} > connection_test.log) )
+            ### on( client,
+            ###    %Q(egrep '^(202|4[0-9][0-9]|5[0-9][0-9]|6|7|9)' connection_test.log),
+            ###    :acceptable_exit_codes => [1]
+            ###  )
+          end
+        end
       end
-
-      it 'should configure server without errors' do
-        set_hieradata_on(server, server_hieradata)
-        apply_manifest_on(server, server_manifest, :catch_failures => false)
-        # Our exec 'hack' takes an extra run.
-        apply_manifest_on(server, server_manifest, :catch_failures => true)
-      end
-
-      it 'should configure server idempotently' do
-        apply_manifest_on(server, server_manifest, :catch_changes => true)
-      end
-
-      it 'should configure client without errors' do
-        set_hieradata_on(client, client_hieradata)
-        apply_manifest_on(client, client_manifest, :catch_failures => true)
-      end
-
-      it 'should configure client idempotently' do
-        apply_manifest_on(client, client_manifest, :catch_changes => true)
-      end
-    end
-
-    context 'connection' do
-      let(:curl_ftp_cmd){ "curl --verbose ftp://#{server_fqdn}/pub/" }
-
-      it 'should successfully log in with active anonymous FTP' do
-        on( client, "#{curl_ftp_cmd} -P -", :acceptable_exit_codes => [0] )
-      end
-
-      it 'should successfully download a file using anonymous FTP' do
-        on( client, "#{curl_ftp_cmd}/TEST.download.#{@msg_uuid[__FILE__]}", :acceptable_exit_codes => [0] )
-      end
-
-      # anonymous FTP cannot upload by default
-      it 'should fail to upload a file using anonymous FTP' do
-        on( client, %Q(#{curl_ftp_cmd} -T /root/TEST.upload.#{@msg_uuid[__FILE__]}), :acceptable_exit_codes => [25] )
-      end
-
-      ### # NOTE: Commented out because FTP client is ridiculous, but keeping in back
-      ###         pocket because there's a chance we might want it and it was a PITA
-      ###         to set up.  Remove before committing.
-      ###  let(:netrc_template) {
-      ###    <<-EOS
-      ###machine SERVER
-      ###        login LOGIN
-      ###        password PASSWORD
-      ###
-      ###macdef connection_test
-      ###        cd /pub
-      ###        ls -la
-      ###        quit
-      ###
-      ###macdef upload_test
-      ###        cd /pub/tests
-      ###        bin
-      ###        put filename.tar.gz
-      ###        quit
-      ###
-      ###    EOS
-      ###  }
-      # wget handles FTP and returns exit codes on failure
-      # on( client, %Q(wget --no-passive-ftp --spider ftp://#{server_fqdn}/pub/), :acceptable_exit_codes => [0] )
-      # curl handles FTP and returns exit codes on failure
-      # stage a .netrc file
-      ### netrc_text = netrc_template
-      ###               .sub( 'SERVER',   server_fqdn   )
-      ###               .sub( 'LOGIN',    'anonymous'   )
-      ###               .sub( 'PASSWORD', 'foo@foo.foo' )
-      ### apply_manifest_on(client, "file{'/root/.netrc': content => '#{netrc_text}' }", :catch_failures => true)
-
-      ### connect to FTP server, then check log for FTP error codes
-      ### on( client, %Q(echo "\\$ connection_test" | ftp #{server_fqdn} > connection_test.log) )
-      ### on( client,
-      ###    %Q(egrep '^(202|4[0-9][0-9]|5[0-9][0-9]|6|7|9)' connection_test.log),
-      ###    :acceptable_exit_codes => [1]
-      ###  )
     end
   end
 end

--- a/spec/acceptance/suites/default/10_ftp_tls_connection_spec.rb
+++ b/spec/acceptance/suites/default/10_ftp_tls_connection_spec.rb
@@ -2,162 +2,168 @@ require 'spec_helper_acceptance'
 
 test_name 'ftp tls connection'
 
-# FIXME: EL6 support is broken with a bug in curl 7.19.X that drops
-# ftp-ssl connections. Look into different client usage in the
-# future.
-#['6', '7'].each do |os_major_version|
-['7'].each do |os_major_version|
+describe 'An FTP-over-TLS session' do
+  hosts_with_role(hosts, 'server').each do |server|
+    describe "with server '#{server}'" do
 
-  describe "An FTP-over-TLS session for CentOS #{os_major_version}" do
-    before(:all) do
-      # Ensure that our test doesn't match messages from other tests
-      @msg_uuid = @msg_uuid || {}
-      @msg_uuid[__FILE__] = Time.now.to_f.to_s.gsub('.','_') + '_TLS'
-    end
-
-    let(:client) { only_host_with_role( hosts, "client#{os_major_version}" ) }
-    let(:server) { only_host_with_role( hosts, "server#{os_major_version}" ) }
-    let(:client_fqdn){ fact_on( client, 'fqdn' ) }
-    let(:server_fqdn){ fact_on( server, 'fqdn' ) }
-
-    let(:client_manifest) {
-      <<-EOS
-        # Switch firewall control from firewalld over to iptables in EL7
-        # Presumably this would already be done on a runnying system.
-        include 'iptables'
-        iptables::listen::tcp_stateful { 'ssh':
-          dports => 22,
-          trusted_nets => ['any'],
-        }
-        # ephemeral ports for FTP's "active mode"
-        iptables::listen::tcp_stateful { 'ephemeral_ports':
-          dports => '32768:61000',
-          trusted_nets => ['any'],
-        }
-
-        file{ '/root/TEST.upload.#{@msg_uuid[__FILE__]}':
-          ensure  => 'file',
-          content => '123',
-          mode    => '644',
-          owner   => 'root',
-        }
-
-        # A client to test the FTP connection
-        # (curl gives nice exit codes and supports FTP-over-SSL)
-        package{ 'curl': ensure => present }
-      EOS
-    }
-
-    let(:client_hieradata) {{
-      'simp_options::firewall'     => true,
-      'simp_options::trusted_nets' => ['any']
-    }}
-
-    let(:server_manifest) {
-      <<-EOS
-        # Switch firewall control from firewalld over to iptables in EL7
-        # Presumably this would already be done on a running system.
-        include 'iptables'
-        iptables::listen::tcp_stateful { 'ssh':
-          dports => 22,
-          trusted_nets => ['0.0.0.0/0'],
-        }
-
-        user{ 'foo':
-          password   => '$1$MpLw9Ljh$wCbneeNVSYQt8L3slbjrs.', # H35zUl5mA4Fiiy3KT
-          home       => '/home/foo',
-          managehome => true,
-        }
-
-        file{ '/home/foo':
-          ensure => 'directory',
-          owner => 'foo',
-          group => 'foo',
-          mode => '0600',
-        }
-        ->
-        file{ '/home/foo/TEST.download.#{@msg_uuid[__FILE__]}':
-          ensure  => 'file',
-          content => '456',
-          mode    => '644',
-          owner   => 'foo',
-        }
-
-        # install and start vsftpd with SSL
-        class { 'vsftpd':
-          ssl_enable        => true,
-          local_enable      => true,
-          pasv_enable       => true,
-          pasv_min_port     => 10000,
-          pasv_max_port     => 10100,
-          require_ssl_reuse => false, # NOTE: curl doesn't support SSL reuse
-        }
-      EOS
-    }
-
-    let(:server_hieradata) {{
-      'simp_options::firewall'     => true,
-      'simp_options::pki'          => true,
-      'simp_options::pki::source'  => '/etc/pki/simp-testing/pki',
-      'simp_options::trusted_nets' => ['0.0.0.0/0'],
-      'simp_options::auditd'       => false,
-      'enable_auditing'            => false, # TODO remove this once pki module is ported over
-    }}
-
-    context 'puppet apply' do
-
-      it 'should install epel' do
-        install_package(server, 'epel-release')
-        install_package(client, 'epel-release')
-      end
-
-      it 'should configure server without errors' do
-        set_hieradata_on(server, server_hieradata)
-        apply_manifest_on(server, server_manifest, :catch_failures => true)
-      end
-
-      it 'should configure server idempotently' do
-        apply_manifest_on(server, server_manifest, :catch_changes => true)
-      end
-
-      it 'should configure client without errors' do
-        set_hieradata_on(client, client_hieradata)
-        apply_manifest_on(client, client_manifest, :catch_failures => true)
-      end
-
-      it 'should configure client idempotently' do
-        apply_manifest_on(client, client_manifest, :catch_changes => true)
-      end
-    end
-
-    context 'connection' do
-
-      let(:curl_ftp_cmd) {
-        'curl --verbose --cacert /etc/pki/simp-testing/pki/cacerts/cacerts.pem ' +
-        "--key /etc/pki//simp-testing/pki/private/#{client_fqdn}.pem " +
-        "--cert /etc/pki/simp-testing/pki/public/#{client_fqdn}.pub " +
-        "--ftp-ssl ftp://foo:H35zUl5mA4Fiiy3KT@#{server_fqdn}"
-        # ^^ these arguments are deprecated in modern curl, but EL6 needs them.
-        # In the future, '--ssl --ssl-reqd' should replace '--ftp-ssl' here
-      }
-
-      it 'should successfully log in a user using FTP-over-SSL' do
-        on( client, curl_ftp_cmd, :acceptable_exit_codes => [0] )
-      end
-
-      it 'should successfully download a file using FTP-over-SSL' do
-        # selinux policy by default does not allow ftp in home directories
-        bools = Hash[on( server, 'getsebool -a' ).stdout.split("\n").map{|x| x.split(/\s+-->\s+/)}]
-
-        if bools.keys.include?('ftp_home_dir')
-          on( server, 'setsebool -P ftp_home_dir=1' )
+      # Why all the sudden this matters now, I have no idea :-|
+      context 'system prep' do
+        it 'should allow ftpd_full_access in selinux' do
+          on(server, 'setsebool -P ftpd_full_access=1', :accept_all_exit_codes => true)
+          on(server, 'setsebool -P allow_ftpd_full_access=1', :accept_all_exit_codes => true)
         end
-
-        on( client, "#{curl_ftp_cmd}/TEST.download.#{@msg_uuid[__FILE__]}", :acceptable_exit_codes => [0] )
       end
 
-      it 'should successfully upload a file using FTP-over-SSL' do
-        on( client, %Q(#{curl_ftp_cmd} -T /root/TEST.upload.#{@msg_uuid[__FILE__]}), :acceptable_exit_codes => [0] )
+      hosts_with_role(hosts, 'client').each do |client|
+        describe "with client '#{client}'" do
+          before(:all) do
+            # Ensure that our test doesn't match messages from other tests
+            @msg_uuid = @msg_uuid || {}
+            @msg_uuid[__FILE__] = Time.now.to_f.to_s.gsub('.','_') + '_TLS'
+          end
+
+          let(:client_fqdn){ fact_on( client, 'fqdn' ) }
+          let(:server_fqdn){ fact_on( server, 'fqdn' ) }
+
+          let(:client_manifest) {
+            <<-EOS
+              include 'iptables'
+
+              iptables::listen::tcp_stateful { 'ssh':
+                dports => 22,
+                trusted_nets => ['any'],
+              }
+              # ephemeral ports for FTP's "active mode"
+              iptables::listen::tcp_stateful { 'ephemeral_ports':
+                dports => '32768:61000',
+                trusted_nets => ['any'],
+              }
+
+              file{ '/root/TEST.upload.#{@msg_uuid[__FILE__]}':
+                ensure  => 'file',
+                content => '123',
+                mode    => '644',
+                owner   => 'root',
+              }
+
+              # A client to test the FTP connection
+              package{ 'lftp': ensure => present }
+            EOS
+          }
+
+          let(:client_hieradata) {{
+            'simp_options::firewall'     => true,
+            'simp_options::trusted_nets' => ['any']
+          }}
+
+          let(:server_manifest) {
+            <<-EOS
+              # Switch firewall control from firewalld over to iptables in EL7
+              # Presumably this would already be done on a running system.
+              include 'iptables'
+              iptables::listen::tcp_stateful { 'ssh':
+                dports => 22,
+                trusted_nets => ['0.0.0.0/0'],
+              }
+
+              user{ 'foo':
+                password   => '$1$MpLw9Ljh$wCbneeNVSYQt8L3slbjrs.', # H35zUl5mA4Fiiy3KT
+                home       => '/home/foo',
+                managehome => true,
+              }
+
+              file{ '/home/foo':
+                ensure  => 'directory',
+                owner   => 'foo',
+                group   => 'foo',
+                mode    => '0600'
+              }
+              ->
+              file{ '/home/foo/TEST.download.#{@msg_uuid[__FILE__]}':
+                ensure  => 'file',
+                content => '456',
+                mode    => '644',
+                owner   => 'foo',
+              }
+
+              # install and start vsftpd with SSL
+              class { 'vsftpd':
+                local_enable  => true,
+                ssl_enable    => true,
+                pasv_min_port => 10000,
+                pasv_max_port => 10100,
+              }
+            EOS
+          }
+
+          let(:server_hieradata) {{
+            'simp_options::firewall'     => true,
+            'simp_options::pki'          => true,
+            'simp_options::pki::source'  => '/etc/pki/simp-testing/pki',
+            'simp_options::trusted_nets' => ['0.0.0.0/0'],
+            'simp_options::auditd'       => false,
+          }}
+
+          context 'puppet apply' do
+            it 'should install epel' do
+              install_package(server, 'epel-release')
+              install_package(client, 'epel-release')
+            end
+
+            it 'should configure server without errors' do
+              set_hieradata_on(server, server_hieradata)
+              apply_manifest_on(server, server_manifest, :catch_failures => true)
+            end
+
+            it 'should configure server idempotently' do
+              apply_manifest_on(server, server_manifest, :catch_changes => true)
+            end
+
+            it 'should configure client without errors' do
+              set_hieradata_on(client, client_hieradata)
+              apply_manifest_on(client, client_manifest, :catch_failures => true)
+            end
+
+            it 'should configure client idempotently' do
+              apply_manifest_on(client, client_manifest, :catch_changes => true)
+            end
+          end
+
+          context 'connection' do
+            let(:lftp_config) { <<~EOM
+                set ssl:ca-file "/etc/pki/simp-testing/pki/cacerts/cacerts.pem"
+                set ssl:check-hostname true
+                set ssl:key-file "/etc/pki//simp-testing/pki/private/#{client_fqdn}.pem"
+                set ssl:cert-file "/etc/pki/simp-testing/pki/public/#{client_fqdn}.pub"
+              EOM
+            }
+            let(:ftp_cmd) { "lftp --user=foo --password=H35zUl5mA4Fiiy3KT ftp://#{server_fqdn}" }
+
+            it 'should create the lftp configuration' do
+              homedir = on(client, 'echo $HOME').stdout.strip
+              create_remote_file(client, "#{homedir}/.lftprc", lftp_config)
+            end
+
+            it 'should successfully log in a user using FTP-over-SSL' do
+              on( client, "#{ftp_cmd} -e 'ls; exit'" , :acceptable_exit_codes => [0] )
+            end
+
+            it 'should successfully download a file using FTP-over-SSL' do
+              # selinux policy by default does not allow ftp in home directories
+              bools = Hash[on( server, 'getsebool -a' ).stdout.split("\n").map{|x| x.split(/\s+-->\s+/)}]
+
+              if bools.keys.include?('ftp_home_dir')
+                on( server, 'setsebool -P ftp_home_dir=1' )
+              end
+
+              on( client, "#{ftp_cmd} -e 'get TEST.download.#{@msg_uuid[__FILE__]}; exit'", :acceptable_exit_codes => [0] )
+            end
+
+            it 'should successfully upload a file using FTP-over-SSL' do
+              on( client, %Q(#{ftp_cmd} -e 'put /root/TEST.upload.#{@msg_uuid[__FILE__]}; exit'), :acceptable_exit_codes => [0] )
+            end
+          end
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -144,6 +144,7 @@ RSpec.configure do |c|
     Puppet[:environmentpath] = @spec_global_env_temp
     Puppet[:user] = Etc.getpwuid(Process.uid).name
     Puppet[:group] = Etc.getgrgid(Process.gid).name
+    Puppet[:digest_algorithm] = 'sha256'
 
     # sanitize hieradata
     if defined?(hieradata)


### PR DESCRIPTION
- Add EL8 support
- The following dependencies are now optional
  - simp/haveged
  - simp/iptables
  - simp/pki
  - simp/tcpwrappers
- Updated acceptance tests to use lftp in TLS mode and fixed SELinux issues
- Updated the README

SIMP-7461 #close