### PR TITLE
(SIMP-9888) Ensure min stdlib is 6.6.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.18.0 < 8.0.0"
+      "version_requirement": ">= 6.6.0 < 8.0.0"
     }
   ],
   "simp": {


### PR DESCRIPTION
This patch ensures the minimum puppetlabs/stdlib version is `6.6.0`.

[SIMP-9967] #close
[SIMP-9888] #comment pupmod-simp-vsftpd stdlib >= 6.6.0

[SIMP-9967]: https://simp-project.atlassian.net/browse/SIMP-9967
[SIMP-9888]: https://simp-project.atlassian.net/browse/SIMP-9888