### PR TITLE
(SIMP-10204) Ensure testing with CentOS 8.4

### DIFF
--- a/spec/acceptance/nodesets/centos.yml
+++ b/spec/acceptance/nodesets/centos.yml
@@ -23,13 +23,13 @@ HOSTS:
     roles:
       - server
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
   el8-client:
     roles:
       - client
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -13,11 +13,6 @@ HOSTS:
     platform: el-7-x86_64
     box: generic/oracle7
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   oel7-client:
     roles:
@@ -25,11 +20,6 @@ HOSTS:
     platform: el-7-x86_64
     box: generic/oracle7
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   oel8-server:
     roles:
@@ -37,11 +27,6 @@ HOSTS:
     platform: el-8-x86_64
     box: generic/oracle8
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
   oel8-client:
     roles:
@@ -49,11 +34,6 @@ HOSTS:
     platform: el-8-x86_64
     box: generic/oracle8
     hypervisor: <%= hypervisor %>
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch'
-        gpgkeys:
-          - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -13,12 +13,6 @@ hosts_with_role(hosts, 'server').each do |server|
       EOS
     }
 
-    context 'setup' do
-      it 'should install epel' do
-        install_package(server, 'epel-release')
-      end
-    end
-
     context 'default parameters with SIMP pki' do
 
       it 'should work with no errors' do

--- a/spec/acceptance/suites/default/05_ftp_connection_spec.rb
+++ b/spec/acceptance/suites/default/05_ftp_connection_spec.rb
@@ -80,11 +80,6 @@ describe 'An anonymous (plaintext) FTP session' do
 
           context 'basic puppet apply' do
 
-            it 'should install epel' do
-              install_package(server, 'epel-release')
-              install_package(client, 'epel-release')
-            end
-
             it 'should configure server without errors' do
               set_hieradata_on(server, server_hieradata)
               apply_manifest_on(server, server_manifest, :catch_failures => false)

--- a/spec/acceptance/suites/default/10_ftp_tls_connection_spec.rb
+++ b/spec/acceptance/suites/default/10_ftp_tls_connection_spec.rb
@@ -105,11 +105,6 @@ describe 'An FTP-over-TLS session' do
           }}
 
           context 'puppet apply' do
-            it 'should install epel' do
-              install_package(server, 'epel-release')
-              install_package(client, 'epel-release')
-            end
-
             it 'should configure server without errors' do
               set_hieradata_on(server, server_hieradata)
               apply_manifest_on(server, server_manifest, :catch_failures => true)

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe 'vsftpd' do
   on_supported_os.each do |os, facts|
     let(:facts) do
-      facts.merge( { :fqdn => 'test.host.simp' } )
+      facts.merge( { :fqdn => 'test.host.simp',
+                     :haveged__rngd_enabled => false } )
     end
 
     context "on #{os}" do


### PR DESCRIPTION
- update the EL8 nodes in the acceptance tests
  to run with generic/centos8 to make sure they using
  CentOS 8.4
- remove epel repos from nodeset.  Epel repos are added automatically
  by simp-beaker-helpers

SIMP-10204 #comment vsftp updated
SIMP-10253 #close